### PR TITLE
Helped make this ready for contribution to MELPA

### DIFF
--- a/.github/workflows/melpa.yaml
+++ b/.github/workflows/melpa.yaml
@@ -1,0 +1,38 @@
+name: check
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Run MELPA checks
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - 27.1
+          - 29.3
+          - release-snapshot
+        include:
+          - emacs_version: snapshot
+          - ignore_warnings: false
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+        - name: Setup Emacs
+          uses: purcell/setup-emacs@master
+          with:
+            version: ${{ matrix.emacs_version }}
+        - name: Run MELPA checks on package
+          uses: leotaku/elisp-check@master
+          with:
+            check: melpa
+            file: '*.el'
+            ignore_warnings: false
+            warnings_as_errors: false

--- a/.github/workflows/melpa.yaml
+++ b/.github/workflows/melpa.yaml
@@ -33,6 +33,6 @@ jobs:
           uses: leotaku/elisp-check@master
           with:
             check: melpa
-            file: '*.el'
+            file: '*gnome-search.el'
             ignore_warnings: false
             warnings_as_errors: false

--- a/consult-gnome-search.el
+++ b/consult-gnome-search.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2024  Jürgen Hötzel, Alexis Purslane
 
 ;; Author: Jürgen Hötzel <juergen@hoetzel.info>, Alexis Purslane <alexispurslane@pm.me>
-;; URL: https://github.com/alexispurslane/consult-gnome-search
+;; URL: https://github.com/juergenhoetzel/consult-gnome-search
 ;; Keywords: convenience
 ;; Version: 0.0.2
 ;; Package-Requires: ((emacs "29.1") (consult "0.8"))
@@ -15,11 +15,11 @@
 
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;; along with this program.	 If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 
@@ -32,155 +32,155 @@
 (require 'url-util)
 
 (defface consult-gnome-search-name
-    '((t :inherit font-lock-function-name-face))
-    "Face used to highlight names in `consult-gnome-search'.")
+	'((t :inherit font-lock-function-name-face))
+	"Face used to highlight names in `consult-gnome-search'.")
 
 (defgroup consult-gnome-search nil
-    "Options concerning consult gnome search."
-    :tag "Consult Gnome Search"
-    :group 'consult-gnome-search)
+	"Options concerning consult gnome search."
+	:tag "Consult Gnome Search"
+	:group 'consult-gnome-search)
 
 
 (defcustom consult-gnome-search-max-results 5
-    "Maximum number of results to receive for a provider.  0
+	"Maximum number of results to receive for a provider.  0
 means no limit."
-    :type 'integer
-    :group 'consult-gnome-search)
+	:type 'integer
+	:group 'consult-gnome-search)
 
 (defun consult-gnome-search-find-nautilus-id (result-id)
-    "Edit filename associated with RESULT-ID which is expected to
+	"Edit filename associated with RESULT-ID which is expected to
 be a file URL."
-    (if-let ((file-name (url-unhex-string (url-filename (url-generic-parse-url result-id)))))
-            (find-file file-name)
-        (warn "Failed to parse result-id %s to as file-name" result-id)))
+	(if-let ((file-name (url-unhex-string (url-filename (url-generic-parse-url result-id)))))
+			(find-file file-name)
+		(warn "Failed to parse result-id %s to as file-name" result-id)))
 
 (defcustom consult-gnome-search-activate-functions '(("org.gnome.Nautilus" . consult-gnome-search-find-nautilus-id))
-    "How the command `consult-gnome-search' activates the result.
+	"How the command `consult-gnome-search' activates the result.
 
-An association list of (PROVIDER . FUNCTION) pairs.  PROVIDER
+An association list of (PROVIDER . FUNCTION) pairs.	 PROVIDER
 identifies bus name of a `gnome-search-provider'.  The associated
 FUNCTION specifies a function of a single result-id argument
 activating the result instead using the default method of the gnome
 search provider"
-    :group 'consult-gnome-search
-    :type '(repeat (cons (string :tag "D-Bus name")
-		                 (function :tag "Activation function"))))
+	:group 'consult-gnome-search
+	:type '(repeat (cons (string :tag "D-Bus name")
+						 (function :tag "Activation function"))))
 
 
 (defun consult-gnome-search--receive-candidates (async provider terms results)
-    (unless (zerop consult-gnome-search-max-results)
-        (setq results (seq-take results consult-gnome-search-max-results)))
-    (let* ((metas (gnome-search-results-metas provider results))
-	       (gs-results (mapcar  (lambda (meta)
-				                    (let ((gs-result (gnome-search--result-from-meta provider meta)))
-                                        ;keep track of search terms (dbus ActivateResult callback)
-				                        (setf (gnome-search-result-terms gs-result) terms) 
-				                        gs-result))
-			                    metas)))
-        (funcall async gs-results)))
+	(unless (zerop consult-gnome-search-max-results)
+		(setq results (seq-take results consult-gnome-search-max-results)))
+	(let* ((metas (gnome-search-results-metas provider results))
+		   (gs-results (mapcar	(lambda (meta)
+									(let ((gs-result (gnome-search--result-from-meta provider meta)))
+										;keep track of search terms (dbus ActivateResult callback)
+										(setf (gnome-search-result-terms gs-result) terms) 
+										gs-result))
+								metas)))
+		(funcall async gs-results)))
 
 (defun consult-gnome-search--transformer (gs-result)
-    "Transformer to produce a completion candidate from
+	"Transformer to produce a completion candidate from
 `gnome-search-result' GS-RESULT."
-    (propertize
-     (concat (if-let ((image (gnome-search--create-image gs-result)))
-	                 (propertize " "		;optional icon
-			                     'display  image))
-	         (gnome-search-result-name gs-result))
-     'consult--candidate gs-result
-     'face 'consult-gnome-search-name))
+	(propertize
+	 (concat (if-let ((image (gnome-search--create-image gs-result)))
+					 (propertize " "		;optional icon
+								 'display  image))
+			 (gnome-search-result-name gs-result))
+	 'consult--candidate gs-result
+	 'face 'consult-gnome-search-name))
 
 (defun consult-gnome-search--async-search (async)
-    "Async search provider for `consult-gnome-search'.
+	"Async search provider for `consult-gnome-search'.
 
 ASYNC is the async function which receives the candidates."
-    (lambda (action)
-        (pcase-exhaustive action
-            ((pred stringp)
-             (when (not (string-empty-p (string-trim action)))
-	             (funcall async #'flush)
-	             (gnome-search-async (string-split action)
-			                         (lambda (provider result)
-			                             (when result
-				                             (consult-gnome-search--receive-candidates
-				                              async provider (string-split action) result))))))
-            (_ (funcall async action))))) 	;FIXME: Catchall?
+	(lambda (action)
+		(pcase-exhaustive action
+			((pred stringp)
+			 (when (not (string-empty-p (string-trim action)))
+				 (funcall async #'flush)
+				 (gnome-search-async (string-split action)
+									 (lambda (provider result)
+										 (when result
+											 (consult-gnome-search--receive-candidates
+											  async provider (string-split action) result))))))
+			(_ (funcall async action)))))	;FIXME: Catchall?
 
 (defun consult-gnome-search-collection ()
-    (thread-first
-        (consult--async-sink)
-        (consult--async-refresh-immediate)
-        (consult--async-map #'consult-gnome-search--transformer)
-        (consult-gnome-search--async-search)
-        (consult--async-throttle)
-        (consult--async-split)))
+	(thread-first
+		(consult--async-sink)
+		(consult--async-refresh-immediate)
+		(consult--async-map #'consult-gnome-search--transformer)
+		(consult-gnome-search--async-search)
+		(consult--async-throttle)
+		(consult--async-split)))
 
 (defun consult-gnome-search--narrow ()
-    "Return narrow key configuration used with `consult-gnome-search'.
+	"Return narrow key configuration used with `consult-gnome-search'.
 
 For the format see `consult--read', for the value types see the
 name slot in `gnome-search--get-providers'."
-    (let ((available-keys `(,@(number-sequence ?A ?Z) ,@(number-sequence ?a ?z)))
-	      narrow-keys)
-        ;; the list of provider-names ist different on each system: Create a deterministic dynamic key configuration
-        (dolist (provider (gnome-search--get-providers))
-            ;; prefer lowercase
-            (if-let ((name (gnome-search-provider-name provider))
-	                 (key (seq-some (lambda (c)
-				                        (car (or (member (downcase c) available-keys) (member (upcase c) available-keys))))
-			                        name)))
-	                (progn
-	                    (push (cons key name) narrow-keys)
-	                    (setq available-keys (delq key available-keys)))
-	            (push (cons (car available-keys) name) narrow-keys)				;fallback, choose random
-	            (setq available-keys (cdr available-keys))))
-        (nreverse narrow-keys)))
+	(let ((available-keys `(,@(number-sequence ?A ?Z) ,@(number-sequence ?a ?z)))
+		  narrow-keys)
+		;; the list of provider-names ist different on each system: Create a deterministic dynamic key configuration
+		(dolist (provider (gnome-search--get-providers))
+			;; prefer lowercase
+			(if-let ((name (gnome-search-provider-name provider))
+					 (key (seq-some (lambda (c)
+										(car (or (member (downcase c) available-keys) (member (upcase c) available-keys))))
+									name)))
+					(progn
+						(push (cons key name) narrow-keys)
+						(setq available-keys (delq key available-keys)))
+				(push (cons (car available-keys) name) narrow-keys)				;fallback, choose random
+				(setq available-keys (cdr available-keys))))
+		(nreverse narrow-keys)))
 
 
 (defun consult-gnome-search--group (cand transform)
-    "Return title for CAND or TRANSFORM the candidate."
-    (if transform cand
-        (gnome-search-provider-name
-         (gnome-search-result-provider (get-text-property 0 'consult--candidate cand)))))
+	"Return title for CAND or TRANSFORM the candidate."
+	(if transform cand
+		(gnome-search-provider-name
+		 (gnome-search-result-provider (get-text-property 0 'consult--candidate cand)))))
 
 (defun consult-gnome-search--activate-result (result)
-    "Activate search result RESULT."
-    (unless (gnome-search-result-p result)
-        (error "Invalid argument: %s" (type-of result)))
-    (let ((id (gnome-search-result-id result))
-	      (bus-name (gnome-search-provider-bus-name (gnome-search-result-provider result)))
-	      (object-path (gnome-search-provider-object-path (gnome-search-result-provider result)))
-	      (timestamp (time-convert nil 'integer))
-	      (search-terms (gnome-search-result-terms result)))
-        (if-let ((f (cdr (assoc bus-name consult-gnome-search-activate-functions))))
-	            (funcall f id)
-            (dbus-call-method :session bus-name object-path "org.gnome.Shell.SearchProvider2" "ActivateResult" id search-terms  timestamp))))
+	"Activate search result RESULT."
+	(unless (gnome-search-result-p result)
+		(error "Invalid argument: %s" (type-of result)))
+	(let ((id (gnome-search-result-id result))
+		  (bus-name (gnome-search-provider-bus-name (gnome-search-result-provider result)))
+		  (object-path (gnome-search-provider-object-path (gnome-search-result-provider result)))
+		  (timestamp (time-convert nil 'integer))
+		  (search-terms (gnome-search-result-terms result)))
+		(if-let ((f (cdr (assoc bus-name consult-gnome-search-activate-functions))))
+				(funcall f id)
+			(dbus-call-method :session bus-name object-path "org.gnome.Shell.SearchProvider2" "ActivateResult" id search-terms	timestamp))))
 
 ;;;###autoload
 (defun consult-gnome-search (&optional initial)
-    "Search gnome search providers given INITIAL input.
+	"Search gnome search providers given INITIAL input.
 
 The input string is not preprocessed and passed literally to the
 underlying man commands."
-    (interactive)
-    (consult-gnome-search--activate-result
-     (consult--read
-      (consult-gnome-search-collection)
-      :prompt "Gnome search: "
-      :sort nil
-      :require-match t
-      :lookup #'consult--lookup-candidate
-      :group #'consult-gnome-search--group
-      :narrow (let ((narrow-key-configuration (consult-gnome-search--narrow)))
-	              (list :predicate
-		                (lambda (cand)
-		                    (let ((narrow-name (cdr (assoc consult--narrow narrow-key-configuration))))
-			                    (equal (gnome-search-provider-name
-				                        (gnome-search-result-provider
-				                         (get-text-property 0 'consult--candidate cand)))
-			                           narrow-name)))
-		                :keys narrow-key-configuration))
-      :category 'consult-gnome-search)))
+	(interactive)
+	(consult-gnome-search--activate-result
+	 (consult--read
+	  (consult-gnome-search-collection)
+	  :prompt "Gnome search: "
+	  :sort nil
+	  :require-match t
+	  :lookup #'consult--lookup-candidate
+	  :group #'consult-gnome-search--group
+	  :narrow (let ((narrow-key-configuration (consult-gnome-search--narrow)))
+				  (list :predicate
+						(lambda (cand)
+							(let ((narrow-name (cdr (assoc consult--narrow narrow-key-configuration))))
+								(equal (gnome-search-provider-name
+										(gnome-search-result-provider
+										 (get-text-property 0 'consult--candidate cand)))
+									   narrow-name)))
+						:keys narrow-key-configuration))
+	  :category 'consult-gnome-search)))
 
 (provide 'consult-gnome-search)
 ;;; consult-gnome-search.el ends here

--- a/consult-gnome-search.el
+++ b/consult-gnome-search.el
@@ -1,11 +1,11 @@
 ;;; consult-gnome-search.el --- Gnome search interface using consult  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024  Jürgen Hötzel
+;; Copyright (C) 2024  Jürgen Hötzel, Alexis Purslane
 
-;; Author: Jürgen Hötzel <juergen@hoetzel.info>
+;; Author: Jürgen Hötzel <juergen@hoetzel.info>, Alexis Purslane <alexispurslane@pm.me>
 ;; Keywords: convenience
-;; Version: 0.0.1
-;; Package-Requires: ((emacs "27.1") (consult "0.8"))
+;; Version: 0.0.2
+;; Package-Requires: ((emacs "29.1") (consult "0.8"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -30,152 +30,152 @@
 (require 'url-util)
 
 (defface consult-gnome-search-name
-  '((t :inherit font-lock-function-name-face))
-  "Face used to highlight names in `consult-gnome-search'.")
+    '((t :inherit font-lock-function-name-face))
+    "Face used to highlight names in `consult-gnome-search'.")
 
 (defgroup consult-gnome-search nil
-  "Options concerning consult gnome search."
-  :tag "Consult Gnome Search"
-  :group 'consult-gnome-search)
+    "Options concerning consult gnome search."
+    :tag "Consult Gnome Search"
+    :group 'consult-gnome-search)
 
 
 (defcustom consult-gnome-search-max-results 5
-  "Maximum number of results to receive for a provider.  0 means no limit."
-  :type 'integer
-  :group 'consult-gnome-search)
+    "Maximum number of results to receive for a provider.  0 means no limit."
+    :type 'integer
+    :group 'consult-gnome-search)
 
 
 (defun consult-gnome-search-find-nautilus-id (result-id)
-  "Edit filename associated with RESULT-ID which is expected to be a file URL."
-  (if-let ((file-name (url-unhex-string (url-filename (url-generic-parse-url result-id)))))
-      (find-file file-name)
-    (warn "Failed to parse result-id %s to as file-name" result-id)))
+    "Edit filename associated with RESULT-ID which is expected to be a file URL."
+    (if-let ((file-name (url-unhex-string (url-filename (url-generic-parse-url result-id)))))
+            (find-file file-name)
+        (warn "Failed to parse result-id %s to as file-name" result-id)))
 
 (defcustom consult-gnome-search-activate-functions '(("org.gnome.Nautilus" . consult-gnome-search-find-nautilus-id))
-  "How the command `consult-gnome-search' activates the result.
+    "How the command `consult-gnome-search' activates the result.
 
 An association list of (PROVIDER . FUNCTION) pairs.  PROVIDER
 identifies bus name of a `gnome-search-provider'.  The associated
 FUNCTION specifies a function of a single result-id argument
 activating the result instead using the default method of the gnome
 search provider"
-  :group 'consult-gnome-search
-  :type '(repeat (cons (string :tag "D-Bus name")
-		       (function :tag "Activation function"))))
+    :group 'consult-gnome-search
+    :type '(repeat (cons (string :tag "D-Bus name")
+		                 (function :tag "Activation function"))))
 
 
 (defun consult-gnome-search--receive-candidates (async provider terms results)
-  (unless (zerop consult-gnome-search-max-results)
-    (setq results (seq-take results consult-gnome-search-max-results)))
-  (let* ((metas (gnome-search-results-metas provider results))
-	 (gs-results (mapcar  (lambda (meta)
-				(let ((gs-result (gnome-search--result-from-meta provider meta)))
-					;keep track of search terms (dbus ActivateResult callback)
-				  (setf (gnome-search-result-terms gs-result) terms) 
-				  gs-result))
-			      metas)))
-    (funcall async gs-results)))
+    (unless (zerop consult-gnome-search-max-results)
+        (setq results (seq-take results consult-gnome-search-max-results)))
+    (let* ((metas (gnome-search-results-metas provider results))
+	       (gs-results (mapcar  (lambda (meta)
+				                    (let ((gs-result (gnome-search--result-from-meta provider meta)))
+                                        ;keep track of search terms (dbus ActivateResult callback)
+				                        (setf (gnome-search-result-terms gs-result) terms) 
+				                        gs-result))
+			                    metas)))
+        (funcall async gs-results)))
 
 (defun consult-gnome-search--transformer (gs-result)
-  "Transformer to produce a completion candidate from `gnome-search-result' GS-RESULT."
-  (propertize
-   (concat (if-let ((image (gnome-search--create-image gs-result)))
-	       (propertize " "		;optional icon
-			   'display  image))
-	   (gnome-search-result-name gs-result))
-   'consult--candidate gs-result
-   'face 'consult-gnome-search-name))
+    "Transformer to produce a completion candidate from `gnome-search-result' GS-RESULT."
+    (propertize
+     (concat (if-let ((image (gnome-search--create-image gs-result)))
+	                 (propertize " "		;optional icon
+			                     'display  image))
+	         (gnome-search-result-name gs-result))
+     'consult--candidate gs-result
+     'face 'consult-gnome-search-name))
 
 (defun consult-gnome--async-search (async)
-  "Async search provider for `consult-gnome-search'
+    "Async search provider for `consult-gnome-search'
 
   ASYNC is the async function which receives the candidates."
-  (lambda (action)
-    (pcase-exhaustive action
-      ((pred stringp)
-       (when (not (string-empty-p (string-trim action)))
-	 (funcall async #'flush)
-	 (gnome-search-async (string-split action)
-			     (lambda (provider result)
-			       (when result
-				 (consult-gnome-search--receive-candidates
-				  async provider (string-split action) result))))))
-      (_ (funcall async action))))) 	;FIXME: Catchall?
+    (lambda (action)
+        (pcase-exhaustive action
+            ((pred stringp)
+             (when (not (string-empty-p (string-trim action)))
+	             (funcall async #'flush)
+	             (gnome-search-async (string-split action)
+			                         (lambda (provider result)
+			                             (when result
+				                             (consult-gnome-search--receive-candidates
+				                              async provider (string-split action) result))))))
+            (_ (funcall async action))))) 	;FIXME: Catchall?
 
 (defun consult-gnome-search-collection ()
-  (thread-first
-    (consult--async-sink)
-    (consult--async-refresh-immediate)
-    (consult--async-map #'consult-gnome-search--transformer)
-    (consult-gnome--async-search)
-    (consult--async-throttle)
-    (consult--async-split)))
+    (thread-first
+        (consult--async-sink)
+        (consult--async-refresh-immediate)
+        (consult--async-map #'consult-gnome-search--transformer)
+        (consult-gnome--async-search)
+        (consult--async-throttle)
+        (consult--async-split)))
 
 (defun consult-gnome-search--narrow ()
-  "Return narrow key configuration used with `consult-gnome-search'.
+    "Return narrow key configuration used with `consult-gnome-search'.
   For the format see `consult--read', for the value types see the
   name slot in `gnome-search--get-providers'."
-  (let ((available-keys `(,@(number-sequence ?A ?Z) ,@(number-sequence ?a ?z)))
-	narrow-keys)
-    ;; the list of provider-names ist different on each system: Create a deterministic dynamic key configuration
-    (dolist (provider (gnome-search--get-providers))
-      ;; prefer lowercase
-      (if-let ((name (gnome-search-provider-name provider))
-	       (key (seq-some (lambda (c)
-				(car (or (member (downcase c) available-keys) (member (upcase c) available-keys))))
-			      name)))
-	  (progn
-	    (push (cons key name) narrow-keys)
-	    (setq available-keyes (delq key available-keys)))
-	(push (cons (car available-keys) name) narrow-keys)				;fallback, choose random
-	(setq available-keyes (cdr available-keys))))
-    (nreverse narrow-keys)))
+    (let ((available-keys `(,@(number-sequence ?A ?Z) ,@(number-sequence ?a ?z)))
+	      narrow-keys)
+        ;; the list of provider-names ist different on each system: Create a deterministic dynamic key configuration
+        (dolist (provider (gnome-search--get-providers))
+            ;; prefer lowercase
+            (if-let ((name (gnome-search-provider-name provider))
+	                 (key (seq-some (lambda (c)
+				                        (car (or (member (downcase c) available-keys) (member (upcase c) available-keys))))
+			                        name)))
+	                (progn
+	                    (push (cons key name) narrow-keys)
+	                    (setq available-keyes (delq key available-keys)))
+	            (push (cons (car available-keys) name) narrow-keys)				;fallback, choose random
+	            (setq available-keyes (cdr available-keys))))
+        (nreverse narrow-keys)))
 
 
 (defun consult-gnome-search--group (cand transform)
-  "Return title for CAND or TRANSFORM the candidate."
-  (if transform cand
-    (gnome-search-provider-name
-     (gnome-search-result-provider (get-text-property 0 'consult--candidate cand)))))
+    "Return title for CAND or TRANSFORM the candidate."
+    (if transform cand
+        (gnome-search-provider-name
+         (gnome-search-result-provider (get-text-property 0 'consult--candidate cand)))))
 
 (defun consult-gnome-search--activate-result (result)
-  "Activate search result RESULT."
-  (unless (gnome-search-result-p result)
-    (error "Invalid argument: %s" (type-of result)))
-  (let ((id (gnome-search-result-id result))
-	(bus-name (gnome-search-provider-bus-name (gnome-search-result-provider result)))
-	(object-path (gnome-search-provider-object-path (gnome-search-result-provider result)))
-	(timestamp (time-convert nil 'integer))
-	(search-terms (gnome-search-result-terms result)))
-    (if-let ((f (cdr (assoc bus-name consult-gnome-search-activate-functions))))
-	(funcall f id)
-      (dbus-call-method :session bus-name object-path "org.gnome.Shell.SearchProvider2" "ActivateResult" id search-terms  timestamp))))
+    "Activate search result RESULT."
+    (unless (gnome-search-result-p result)
+        (error "Invalid argument: %s" (type-of result)))
+    (let ((id (gnome-search-result-id result))
+	      (bus-name (gnome-search-provider-bus-name (gnome-search-result-provider result)))
+	      (object-path (gnome-search-provider-object-path (gnome-search-result-provider result)))
+	      (timestamp (time-convert nil 'integer))
+	      (search-terms (gnome-search-result-terms result)))
+        (if-let ((f (cdr (assoc bus-name consult-gnome-search-activate-functions))))
+	            (funcall f id)
+            (dbus-call-method :session bus-name object-path "org.gnome.Shell.SearchProvider2" "ActivateResult" id search-terms  timestamp))))
 
 ;;;###autoload
 (defun consult-gnome-search (&optional initial)
-  "Search gnome search providers given INITIAL input.
+    "Search gnome search providers given INITIAL input.
 
   The input string is not preprocessed and passed literally to the
   underlying man commands."
-  (interactive)
-  (consult-gnome-search--activate-result
-   (consult--read
-    (consult-gnome-search-collection)
-    :prompt "Gnome search: "
-    :sort nil
-    :require-match t
-    :lookup #'consult--lookup-candidate
-    :group #'consult-gnome-search--group
-    :narrow (let ((narrow-key-configuration (consult-gnome-search--narrow)))
-	      (list :predicate
-		    (lambda (cand)
-		      (let ((narrow-name (cdr (assoc consult--narrow narrow-key-configuration))))
-			(equal (gnome-search-provider-name
-				(gnome-search-result-provider
-				 (get-text-property 0 'consult--candidate cand)))
-			       narrow-name)))
-		    :keys narrow-key-configuration))
-    :category 'consult-gnome-search)))
+    (interactive)
+    (consult-gnome-search--activate-result
+     (consult--read
+      (consult-gnome-search-collection)
+      :prompt "Gnome search: "
+      :sort nil
+      :require-match t
+      :lookup #'consult--lookup-candidate
+      :group #'consult-gnome-search--group
+      :narrow (let ((narrow-key-configuration (consult-gnome-search--narrow)))
+	              (list :predicate
+		                (lambda (cand)
+		                    (let ((narrow-name (cdr (assoc consult--narrow narrow-key-configuration))))
+			                    (equal (gnome-search-provider-name
+				                        (gnome-search-result-provider
+				                         (get-text-property 0 'consult--candidate cand)))
+			                           narrow-name)))
+		                :keys narrow-key-configuration))
+      :category 'consult-gnome-search)))
 
 (provide 'consult-gnome-search)
 ;;; consult-gnome-search.el ends here

--- a/consult-gnome-search.el
+++ b/consult-gnome-search.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2024  Jürgen Hötzel, Alexis Purslane
 
 ;; Author: Jürgen Hötzel <juergen@hoetzel.info>, Alexis Purslane <alexispurslane@pm.me>
+;; URL: https://github.com/alexispurslane/consult-gnome-search
 ;; Keywords: convenience
 ;; Version: 0.0.2
 ;; Package-Requires: ((emacs "29.1") (consult "0.8"))
@@ -22,7 +23,8 @@
 
 ;;; Commentary:
 
-;; 
+;; Trying to figure out how to add description metadata as an
+;; annotation to consult -- alexis
 
 ;;; Code:
 
@@ -40,13 +42,14 @@
 
 
 (defcustom consult-gnome-search-max-results 5
-    "Maximum number of results to receive for a provider.  0 means no limit."
+    "Maximum number of results to receive for a provider.  0
+means no limit."
     :type 'integer
     :group 'consult-gnome-search)
 
-
 (defun consult-gnome-search-find-nautilus-id (result-id)
-    "Edit filename associated with RESULT-ID which is expected to be a file URL."
+    "Edit filename associated with RESULT-ID which is expected to
+be a file URL."
     (if-let ((file-name (url-unhex-string (url-filename (url-generic-parse-url result-id)))))
             (find-file file-name)
         (warn "Failed to parse result-id %s to as file-name" result-id)))
@@ -77,7 +80,8 @@ search provider"
         (funcall async gs-results)))
 
 (defun consult-gnome-search--transformer (gs-result)
-    "Transformer to produce a completion candidate from `gnome-search-result' GS-RESULT."
+    "Transformer to produce a completion candidate from
+`gnome-search-result' GS-RESULT."
     (propertize
      (concat (if-let ((image (gnome-search--create-image gs-result)))
 	                 (propertize " "		;optional icon
@@ -86,10 +90,10 @@ search provider"
      'consult--candidate gs-result
      'face 'consult-gnome-search-name))
 
-(defun consult-gnome--async-search (async)
-    "Async search provider for `consult-gnome-search'
+(defun consult-gnome-search--async-search (async)
+    "Async search provider for `consult-gnome-search'.
 
-  ASYNC is the async function which receives the candidates."
+ASYNC is the async function which receives the candidates."
     (lambda (action)
         (pcase-exhaustive action
             ((pred stringp)
@@ -107,14 +111,15 @@ search provider"
         (consult--async-sink)
         (consult--async-refresh-immediate)
         (consult--async-map #'consult-gnome-search--transformer)
-        (consult-gnome--async-search)
+        (consult-gnome-search--async-search)
         (consult--async-throttle)
         (consult--async-split)))
 
 (defun consult-gnome-search--narrow ()
     "Return narrow key configuration used with `consult-gnome-search'.
-  For the format see `consult--read', for the value types see the
-  name slot in `gnome-search--get-providers'."
+
+For the format see `consult--read', for the value types see the
+name slot in `gnome-search--get-providers'."
     (let ((available-keys `(,@(number-sequence ?A ?Z) ,@(number-sequence ?a ?z)))
 	      narrow-keys)
         ;; the list of provider-names ist different on each system: Create a deterministic dynamic key configuration
@@ -126,9 +131,9 @@ search provider"
 			                        name)))
 	                (progn
 	                    (push (cons key name) narrow-keys)
-	                    (setq available-keyes (delq key available-keys)))
+	                    (setq available-keys (delq key available-keys)))
 	            (push (cons (car available-keys) name) narrow-keys)				;fallback, choose random
-	            (setq available-keyes (cdr available-keys))))
+	            (setq available-keys (cdr available-keys))))
         (nreverse narrow-keys)))
 
 
@@ -155,8 +160,8 @@ search provider"
 (defun consult-gnome-search (&optional initial)
     "Search gnome search providers given INITIAL input.
 
-  The input string is not preprocessed and passed literally to the
-  underlying man commands."
+The input string is not preprocessed and passed literally to the
+underlying man commands."
     (interactive)
     (consult-gnome-search--activate-result
      (consult--read

--- a/gnome-search.el
+++ b/gnome-search.el
@@ -1,10 +1,10 @@
-;;; gnome-search.el --- Gnome search interface                -*- lexical-binding: t; -*-
+;;; gnome-search.el --- Gnome search interface				  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2024  Jürgen Hötzel, Alexis Purslane
 
 ;; Author: Jürgen Hötzel <juergen@hoetzel.info>, Alexis Purslane <alexispurslane@pm.me>
 ;; Keywords: convenience
-;; URL: https://github.com/alexispurslane/consult-gnome-search
+;; URL: https://github.com/juergenhoetzel/consult-gnome-search
 ;; Version: 0.0.2
 ;; Package-Requires: ((emacs "29.1"))
 
@@ -15,11 +15,11 @@
 
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;; along with this program.	 If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 
@@ -34,167 +34,166 @@
 (require 'dbus)
 
 (defgroup gnome-search nil
-    "Options concerning GNOME search."
-    :tag "Gnome Search"
-    :group 'gnome-search)
+	"Options concerning GNOME search."
+	:tag "Gnome Search"
+	:group 'gnome-search)
 
 (defcustom gnome-search-providers-directory
-    "/usr/share/gnome-shell/search-providers/"
-    "The directory to look for GNOME Shell Search Providers."
-    :type 'string
-    :group 'gnome-search) ;FIXME: Hardcoded!
+	"/usr/share/gnome-shell/search-providers/"
+	"The directory to look for GNOME Shell Search Providers."
+	:type 'string
+	:group 'gnome-search) ;FIXME: Hardcoded!
 
 (defcustom gnome-search-ignored-names nil "List of ignored dbus search-provider-names"
-    :type '(repeat (string :tag "Bus name: "))
-    :group 'gnome-search)
+	:type '(repeat (string :tag "Bus name: "))
+	:group 'gnome-search)
 
 (defun gnome-search-locate-desktop-file-name (desktop-name)
-    "Return absolute file-name for DESKTOP-NAME.
+	"Return absolute file-name for DESKTOP-NAME.
 
 DESKTOP-NAME must be a .desktop file-name as defined in the XDG Desktop Entry specification."
-    (seq-some (lambda (dir)
-	              (let ((absolute-name (concat (file-name-as-directory dir) "applications/" desktop-name)))
-		              (when (file-exists-p absolute-name)
-		                  absolute-name)))
-	          (xdg-data-dirs)))
+	(seq-some (lambda (dir)
+				  (let ((absolute-name (concat (file-name-as-directory dir) "applications/" desktop-name)))
+					  (when (file-exists-p absolute-name)
+						  absolute-name)))
+			  (xdg-data-dirs)))
 
 
 ;; The basic structure search providers config file
 
 (cl-defstruct (gnome-search-provider)
-    "A record containing the information relevant to a GNOME
+	"A record containing the information relevant to a GNOME
 search provider: a DESKTOP-ID, a BUS-NAME, an OBJECT-PATH, and of
 course a regular NAME."
-    desktop-id bus-name object-path name)
+	desktop-id bus-name object-path name)
 
 (defun gnome-search-make-provider (filename)
-    "Get `gnome-search-provider' structure from FILENAME."
-    (with-temp-buffer
-        (insert-file-contents filename)
-        (let ((provider (make-gnome-search-provider)))
-            (while (search-forward-regexp "\\(.*\\)=\\(.*\\)\n?" nil t)
-	            (setf (pcase (match-string 1)
-		                  ("DesktopId" (gnome-search-provider-desktop-id provider))
-		                  ("BusName" (gnome-search-provider-bus-name provider))
-		                  ("ObjectPath" (gnome-search-provider-object-path provider)))
-	                  (match-string 2)))
-            (if-let* ((file-name (gnome-search-locate-desktop-file-name
-                                  (gnome-search-provider-desktop-id provider)))
-		              (name (gethash "Name" (xdg-desktop-read-file  file-name))))
-	                (setf (gnome-search-provider-name provider) name))
-            provider)))
+	"Get `gnome-search-provider' structure from FILENAME."
+	(with-temp-buffer
+		(insert-file-contents filename)
+		(let ((provider (make-gnome-search-provider)))
+			(while (search-forward-regexp "\\(.*\\)=\\(.*\\)\n?" nil t)
+				(setf (pcase (match-string 1)
+						  ("DesktopId" (gnome-search-provider-desktop-id provider))
+						  ("BusName" (gnome-search-provider-bus-name provider))
+						  ("ObjectPath" (gnome-search-provider-object-path provider)))
+					  (match-string 2)))
+			(if-let* ((file-name (gnome-search-locate-desktop-file-name
+								  (gnome-search-provider-desktop-id provider)))
+					  (name (gethash "Name" (xdg-desktop-read-file	file-name))))
+					(setf (gnome-search-provider-name provider) name))
+			provider)))
 
 (defvar gnome-search-providers nil
-    "List of available `gnome-search-provider' instances.")
+	"List of available `gnome-search-provider' instances.")
 
 (defun gnome-search--get-providers ()
-    "Fetches the list of providers available on your GNOME system
+	"Fetches the list of providers available on your GNOME system
 by checking the `gnome-search-providers-directory' directory for
 =.ini= files."
-    (let ((installed-search-providers (mapcar #'gnome-search-make-provider (directory-files gnome-search-providers-directory t "\.ini$")))
-	      (names (seq-union (dbus-list-known-names :session) (dbus-list-activatable-names :session))))
-        (cl-remove-if (lambda (provider) (or (member (gnome-search-provider-bus-name provider) gnome-search-ignored-names)
-					                         (not (member (gnome-search-provider-bus-name provider) names))))
-		              installed-search-providers)))
+	(let ((installed-search-providers (mapcar #'gnome-search-make-provider (directory-files gnome-search-providers-directory t "\.ini$")))
+		  (names (seq-union (dbus-list-known-names :session) (dbus-list-activatable-names :session))))
+		(cl-remove-if (lambda (provider) (or (member (gnome-search-provider-bus-name provider) gnome-search-ignored-names)
+											 (not (member (gnome-search-provider-bus-name provider) names))))
+					  installed-search-providers)))
 
 (defun gnome-search-internal (provider terms);; FIXME Non-blocking: Remove
-    "Search list of TERMS via search provider PROVIDER."
-    (dbus-call-method
-     :session (gnome-search-provider-bus-name provider) (gnome-search-provider-object-path provider)
-     "org.gnome.Shell.SearchProvider2"
-     "GetInitialResultSet" terms))
+	"Search list of TERMS via search provider PROVIDER."
+	(dbus-call-method
+	 :session (gnome-search-provider-bus-name provider) (gnome-search-provider-object-path provider)
+	 "org.gnome.Shell.SearchProvider2"
+	 "GetInitialResultSet" terms))
 
 (defun gnome-search-results-metas (provider results)
-    "Return list of meta data used to display each given result in RESULTS.
+	"Return list of meta data used to display each given result in RESULTS.
 
 Results is a list of unique matches returned by `gnome-search-provider'."
-    (dbus-call-method
-     :session (gnome-search-provider-bus-name provider) (gnome-search-provider-object-path provider)
-     "org.gnome.Shell.SearchProvider2"
-     "GetResultMetas" results))
+	(dbus-call-method
+	 :session (gnome-search-provider-bus-name provider) (gnome-search-provider-object-path provider)
+	 "org.gnome.Shell.SearchProvider2"
+	 "GetResultMetas" results))
 
 (defun gnome-search-get-provider (desktop-id)
-    "Return `gnome-search-provider' matching string DESKTOP-ID."
-    (cl-find-if  (lambda (provider) (equal (gnome-search-provider-desktop-id provider) desktop-id)) (gnome-search--get-providers)))
+	"Return `gnome-search-provider' matching string DESKTOP-ID."
+	(cl-find-if	 (lambda (provider) (equal (gnome-search-provider-desktop-id provider) desktop-id)) (gnome-search--get-providers)))
 
 (cl-defstruct (gnome-search-result)
-    "A record representing the information contained in a search
+	"A record representing the information contained in a search
 result returned by a GNOME Search Provider."
-    provider id name description icon icon-data terms)
+	provider id name description icon icon-data terms)
 
 (defun gnome-search--result-from-meta (provider metadata)
-    "Constructs a `gnome-search-result' record struct from the
+	"Constructs a `gnome-search-result' record struct from the
 free-form metadata provided by DBus."
-    (let ((result (make-gnome-search-result :provider provider)))
-        (dolist (kv metadata)
-            (pcase (car kv)
-	            ("id" (setf (gnome-search-result-id result) (caadr kv)))
-	            ("name" (setf (gnome-search-result-name result) (caadr kv)))
-	            ("description" (setf (gnome-search-result-description result) (caadr kv)))
-	            ("icon" (setf (gnome-search-result-icon result) (caadr kv)))
-	            ("icon-data" (setf (gnome-search-result-icon-data result) (caadr kv)))))
-        result))
+	(let ((result (make-gnome-search-result :provider provider)))
+		(dolist (kv metadata)
+			(pcase (car kv)
+				("id" (setf (gnome-search-result-id result) (caadr kv)))
+				("name" (setf (gnome-search-result-name result) (caadr kv)))
+				("description" (setf (gnome-search-result-description result) (caadr kv)))
+				("icon" (setf (gnome-search-result-icon result) (caadr kv)))
+				("icon-data" (setf (gnome-search-result-icon-data result) (caadr kv)))))
+		result))
 
 
 (defun gnome-search-internal-async (provider terms callback)
-    "Search list of TERMS via search provider PROVIDER."
-    (dbus-call-method-asynchronously
-     :session (gnome-search-provider-bus-name provider) (gnome-search-provider-object-path provider)
-     "org.gnome.Shell.SearchProvider2"
-     "GetInitialResultSet" callback terms))
+	"Search list of TERMS via search provider PROVIDER."
+	(dbus-call-method-asynchronously
+	 :session (gnome-search-provider-bus-name provider) (gnome-search-provider-object-path provider)
+	 "org.gnome.Shell.SearchProvider2"
+	 "GetInitialResultSet" callback terms))
 
 (defun gnome-search-async (terms callback &optional providers)
-    "Search list of TERMS via all providers.
+	"Search list of TERMS via all providers.
 
 Return an association of results with desktop-id of the provider
 as key."
-    (mapcar (lambda (provider)
-	            (gnome-search-internal-async provider terms
-					                         (apply-partially callback provider)))
-	        (or providers  (gnome-search--get-providers))))
+	(mapcar (lambda (provider)
+				(gnome-search-internal-async provider terms
+											 (apply-partially callback provider)))
+			(or providers  (gnome-search--get-providers))))
 
 (defun gnome-search (terms &optional providers)
-    "Search list of TERMS via all providers.
+	"Search list of TERMS via all providers.
 
 Return an association of results with desktop-id of the provider
 as key."
-    (unless (listp terms)
-        (setq terms (split-string terms)))
-    (thread-last
-        (or providers  (gnome-search--get-providers))
-        (seq-keep (lambda (provider)
-		              (if-let ((results (gnome-search-internal provider terms))
-			                   (metas (gnome-search-results-metas provider results)))
-		                      (mapcar (apply-partially #'gnome-search--result-from-meta provider) metas))))
-        (apply #'append )))
+	(unless (listp terms)
+		(setq terms (split-string terms)))
+	(thread-last
+		(or providers  (gnome-search--get-providers))
+		(seq-keep (lambda (provider)
+					  (if-let ((results (gnome-search-internal provider terms))
+							   (metas (gnome-search-results-metas provider results)))
+							  (mapcar (apply-partially #'gnome-search--result-from-meta provider) metas))))
+		(apply #'append )))
 
 (defun gnome-search--create-image (result &optional save-p)
-    "Create an image from RESULT item received from `gnome-search'.
+	"Create an image from RESULT item received from `gnome-search'.
 
 If optional arg SAVE-P is non-nil, save image as
 gnome-search_NNNN.pbm also as `default-directory')."
-    (if-let ((icon-data (gnome-search-result-icon-data result)))
-            (pcase icon-data
-	            (`(,width  ,height ,stride ,(and (pred booleanp) has-alpha)  8 ,n-channels ,image-data)
-	             (with-temp-buffer
-	                 (insert "P6\n")
-	                 (insert (format "%d %d\n255\n" width height))
-	                 (seq-do-indexed (lambda (b i)
-			                             (unless (and has-alpha (eq (% i n-channels) (1- n-channels))) ;P6 Netpbm doesn't support alpha
-			                                 (insert (byte-to-string b))))
-			                         image-data)
-	                 (when save-p			;for debugging only
-	                     (if-let* ((last-str (car (last (directory-files "." nil "gnome-search_[0-9][0-9][0-9][0-9].pbm"))))
-		                           ((string-match "gnome-search_\\([0-9][0-9][0-9][0-9]\\).pbm" last-str))
-		                           (n2 (1+ (string-to-number (match-string 1 last-str)))))
-		                         (write-region (point-min) (point-max) (format "gnome-search_%04d.pbm" n2))
-	                         (write-region (point-min) (point-max) "gnome-search_0000.pbm")))
-	                 (create-image (string-make-unibyte (buffer-substring-no-properties (point-min) (point-max))) nil t :height ( - (frame-char-height) 2) :ascent 'center)))
-	            (_ (progn (warn "Unknown image-data format: %s" icon-data) nil)))
-        (if-let* ((icon-serialized (gnome-search-result-icon result))
-	              ((string= (car icon-serialized) "file")))
-	            (create-image (url-filename (url-generic-parse-url (caadr icon-serialized))) nil nil :height ( - (frame-char-height) 2) :ascent 'center))))
+	(if-let ((icon-data (gnome-search-result-icon-data result)))
+			(pcase icon-data
+				(`(,width  ,height ,stride ,(and (pred booleanp) has-alpha)	 8 ,n-channels ,image-data)
+				 (with-temp-buffer
+					 (insert "P6\n")
+					 (insert (format "%d %d\n255\n" width height))
+					 (seq-do-indexed (lambda (b i)
+										 (unless (and has-alpha (eq (% i n-channels) (1- n-channels))) ;P6 Netpbm doesn't support alpha
+											 (insert (byte-to-string b))))
+									 image-data)
+					 (when save-p			;for debugging only
+						 (if-let* ((last-str (car (last (directory-files "." nil "gnome-search_[0-9][0-9][0-9][0-9].pbm"))))
+								   ((string-match "gnome-search_\\([0-9][0-9][0-9][0-9]\\).pbm" last-str))
+								   (n2 (1+ (string-to-number (match-string 1 last-str)))))
+								 (write-region (point-min) (point-max) (format "gnome-search_%04d.pbm" n2))
+							 (write-region (point-min) (point-max) "gnome-search_0000.pbm")))
+					 (create-image (string-make-unibyte (buffer-substring-no-properties (point-min) (point-max))) nil t :height ( - (frame-char-height) 2) :ascent 'center)))
+				(_ (progn (warn "Unknown image-data format: %s" icon-data) nil)))
+		(if-let* ((icon-serialized (gnome-search-result-icon result))
+				  ((string= (car icon-serialized) "file")))
+				(create-image (url-filename (url-generic-parse-url (caadr icon-serialized))) nil nil :height ( - (frame-char-height) 2) :ascent 'center))))
 
 (provide 'gnome-search)
 ;;; gnome-search.el ends here
-

--- a/gnome-search.el
+++ b/gnome-search.el
@@ -5,8 +5,8 @@
 ;; Author: Jürgen Hötzel <juergen@hoetzel.info>, Alexis Purslane <alexispurslane@pm.me>
 ;; Keywords: convenience
 ;; Homepage: https://github.com/juergenhoetzel/emacs-gnome-search
-;; Version: 0.0.1
-;; Package-Requires: ((emacs "27.1"))
+;; Version: 0.0.2
+;; Package-Requires: ((emacs "29.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -23,7 +23,10 @@
 
 ;;; Commentary:
 
-;; 
+;; Removed unnecessary dependency on external package ht.el, and
+;; bumped the required version of Emacs high enough to get
+;; seq-union and seq-keep without an external package dependency
+;; either. -- 06/04/2024 Alexis Purslane
 
 ;;; Code:
 
@@ -40,7 +43,7 @@
 (defcustom gnome-search-ignored-names nil "List of ignored dbus search-provider-names"
     :type '(repeat (string :tag "Bus name: ")))
 
-(defun locate-desktop-file-name (desktop-name)
+(defun gnome-search-locate-desktop-file-name (desktop-name)
     "Return absolute file-name for DESKTOP-NAME.
 
 DESKTOP-NAME must be a .desktop file-name as defined in the XDG Desktop Entry specification."
@@ -66,7 +69,8 @@ DESKTOP-NAME must be a .desktop file-name as defined in the XDG Desktop Entry sp
 		                  ("BusName" (gnome-search-provider-bus-name provider))
 		                  ("ObjectPath" (gnome-search-provider-object-path provider)))
 	                  (match-string 2)))
-            (if-let* ((file-name (locate-desktop-file-name (gnome-search-provider-desktop-id provider)))
+            (if-let* ((file-name (gnome-search-locate-desktop-file-name
+                                  (gnome-search-provider-desktop-id provider)))
 		              (name (gethash "Name" (xdg-desktop-read-file  file-name))))
 	                (setf (gnome-search-provider-name provider) name))
             provider)))


### PR DESCRIPTION
- Added a continuous integration system to automatically check that the package byte-compiles and meets MELPA's linting requirements on a few of the most recent Emacs versions.
- Went through and fixed all the lints MELPA considered blockers (and as many of the ones it didn't consider blockers as seemed reasonable)

Also, a few bug testing notes:

- Icons don't show up for me
- Groups don't work for me

and one feature suggestion:

- since you already have the description metadata for results from DBus, it would be really cool if you could add a consult annotation with it. I briefly looked into this, but I'm supposed to be taking a break from Emacs stuff right now, so I didn't go too deeply into it once I saw it would require a bit more plumbing than was easy (basically you'd have to add a separate function, with the keywords `:annotate` to the `consult--read` call, that could look at consult results and get the annotations you wanted out of them, probably from metadata attached to the strings, which I think you already do?)